### PR TITLE
Update SmsService.groovy

### DIFF
--- a/grails-app/services/grails/twilio/SmsService.groovy
+++ b/grails-app/services/grails/twilio/SmsService.groovy
@@ -5,8 +5,9 @@ import groovyx.net.http.Method
 
 import org.apache.http.auth.params.AuthPNames
 import org.apache.http.client.params.AuthPolicy
-import org.codehaus.groovy.grails.commons.ConfigurationHolder as C
-
+//Grails < 2.4 import org.codehaus.groovy.grails.commons.ConfigurationHolder as C
+//Grails >=2.4
+import grails.util.Holders as C
 class SmsService {
 
 	def twilioHttpEndpointBean


### PR DESCRIPTION
With the release of Grails 2.4 the static holders have been deprecated. 
From the [documentation](http://grails.github.io/grails-doc/2.4.3/guide/upgradingFrom23.html)

> Static Holder Classes
> 
> The following deprecated classes have been removed from Grails 2.4.x:
> 
>    org.codehaus.groovy.grails.commons.ApplicationHolder
>   org.codehaus.groovy.grails.commons.ConfigurationHolder
>    org.codehaus.groovy.grails.plugins.PluginManagerHolder
>    org.codehaus.groovy.grails.web.context.ServletContextHolder
>    org.codehaus.groovy.grails.compiler.support.GrailsResourceLoaderHolder
> 
> If you or any plugins you have installed are using these classes you will get a compilation error. The problem can be rectified by updating to new plugins and using grails.util.Holders instead.
